### PR TITLE
Revert changes to use querystring module

### DIFF
--- a/retsly/request.py
+++ b/retsly/request.py
@@ -1,5 +1,5 @@
 import requests
-import querystring
+import jsonurl
 
 class Request:
   def __init__(self, client, method, url, query=None):
@@ -80,7 +80,7 @@ class Request:
     return self.end()
 
   def encodeQS(self):
-    return querystring.stringify_obj(self.query)
+    return jsonurl.query_string(self.query).replace('..', '.')
 
   def getURL(self, id):
     key = '/' + id if (id is not None) else ''

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='retsly',
-    version='1.0.5',
+    version='1.0.8',
     description="A Python wrapper for the Retsly API (https://rets.ly)",
     long_description=read_md('README.md'),
     classifiers=[
@@ -31,6 +31,6 @@ setup(
     ],
     install_requires=[
         'requests',
-        'querystring'
+        'jsonurl'
     ]
 )


### PR DESCRIPTION
Previously we swapped out the jsonurl module with querystring due to a bug with parsing nested query. However, we found that querystring does not work well with nested object either. We will be reverting the changes and simply replacing any double dots in the querystring.